### PR TITLE
Markdown formatting + .sol formatting

### DIFF
--- a/AventusProtocol-ReleaseNotes-v0.4.x.md
+++ b/AventusProtocol-ReleaseNotes-v0.4.x.md
@@ -1,4 +1,4 @@
-﻿Aventus Protocol 0.4.x Release Notes
+﻿# Aventus Protocol 0.4.x Release Notes
 
 This initial public release represents the foundation for everything that will come next; the building blocks to a new, more secure and easier to control way to supply and transact tickets. By developing an open standard that defines how tickets are managed and interacted with throughout the ticketing lifecycle, we can create a new paradigm and a new way to control bots, counterfeits and touting.
 
@@ -6,14 +6,15 @@ The Aventus Protocol provides a backbone of interoperability which will lower ba
 
 The glossary and release notes for version 0.4.x follow, listed by sub-release and category, filtered by status.
 
-Glossary
+### Glossary
 * Event Owner - Ethereum address that is stored as the owner of the event. Has all event-related permissions.
 * Delegates - Other addresses that the owner has given permissions to sell and refund tickets.
 * Apps - Ethereum addresses that can send messages to the blockchain on behalf of an event owner or delegate via a signed message on the blockchain. Apps need an app deposit to access the network.
 
-== Release 0.4.1 - 2018-04-24 ==
+## Release 0.4.1 - 2018-04-24
 
 Breaking changes
+
 * Remove finaliseProposal from event challenges and governance proposals: all proposals now start immediately and use fixed time periods.
 
 Bug Fixes:
@@ -23,36 +24,46 @@ Other
 * Rename ProposalManager to ProposalsManager in migration files, for consistency
 * Publish EventsManager ABI and address in storage, in preparation for upcoming API release
 
-== Release 0.4.0 - 2018-04-17 ==
+## Release 0.4.0 - 2018-04-17
 
-Token Holders
+### Token Holders
+
 New
+
 * Can now create event challenges
 * Can now vote on event challenges
 * Can now receive winnings from event challenges
 
-Event Challengers
+### Event Challengers
+
 New
+
 *  AVT holders can now challenge a suspected fraudulent event as long as they have paid an AVT deposit equal to that of the event being challenged. Challengers receive a percentage of the 'winnings' if their challenge is successful, as well as the event being marked fraudulent.
 * AVT holders can vote on event challenges and receives winnings. Their vote is weighted by the amount of AVT they have staked on the challenge. If the AVT holder has revealed their vote during the revealing period of a challenge and is on the winning side they will receive a share of the winnings.
 * Challenge Enders (AVT Holders who interact with the vote outside of the voting period) can trigger the end of a challenge and receive a percentage of the winnings.
 * If event challenger wins, the event is marked as fraudulent. The losing deposit is distributed amongst the winner, challenge ender and winning voters.
 
-Event Ownership
+### Event Ownership
+
 New
+
 * Event owners can now create an event as long as they have first paid an AVT deposit
 * Event owners can now sell and refund tickets
 * Event owners can now cancel an event as long as no tickets have been sold and the event has not yet occurred. They cannot cancel if their event is under challenge.
 * Third party delegates can now sell and refund tickets for an event
 * Event owners can add and remove the rights of delegates for an event
 
-Governance
+### Governance
+
 New
+
 * Voting can now be held on protocol challenges, as long as the voter has an AVT stake. However, differing to the event challenges, there are no winnings to be distributed after the vote.
 Improved
 * Changes to the protocol can now be suggested as long as the proposer has paid an AVT deposit.
 * Votes are now binary: I agree/I disagree statements
 
-App Registration
+### App Registration
+
 New
+
 * All apps (including delegates) sending event transactions on behalf of others must be registered with Aventus. The user must also have first paid an AVT deposit.

--- a/gitattributes.txt
+++ b/gitattributes.txt
@@ -1,0 +1,3 @@
+# Solidity syntax highlighting
+# see: https://github.com/github/linguist/pull/3973
+*.sol linguist-language=Solidity


### PR DESCRIPTION
The readme txt file was difficult to read on github as a `.txt` file. Switching to `.md` is more readable. 

The contract files did not have syntax highlighting. Github now supports solidity highlighting by adding to a `.gitattributes` file. 