### PR TITLE
Release 0.5.2

### DIFF
--- a/AventusProtocol-ReleaseNotes-v0.5.x.md
+++ b/AventusProtocol-ReleaseNotes-v0.5.x.md
@@ -6,6 +6,14 @@ The audit brought to light a number of issues, none of which were critical, that
 
 The release notes for version 0.5.x follow, listed by sub-release and category, filtered by status.
 
+## Release 0.5.2 - 2018-06-05
+
+Bug fixes:
+* Fix migration error which was breaking LLock proxying.
+
+Efficiency improvements:
+* Do not deploy LAventusTimeMock or LProposalForTesting on the main net
+
 ## Release 0.5.1 - 2018-05-29
 
 Breaking changes:

--- a/migrations/2_libraries.js
+++ b/migrations/2_libraries.js
@@ -42,7 +42,6 @@ function deployLibraries(deployer, network) {
     return deployer.deploy([PProposal, PLock, PEvents, PApps]);
   }).then(() => {
     return deployer.deploy(LLock);
-    LLock.address = PLock.address;
   }).then(() => {
     return deployer.link(LLock, [LProposal, LEvents, LApps]);
   }).then(() => {
@@ -50,7 +49,9 @@ function deployLibraries(deployer, network) {
   }).then(() => {
     return deployer.link(LApps, LEvents);
   }).then(() => {
-    return deployer.deploy([LEvents, LProposalForTesting]);
+    return deployer.deploy(LEvents);
+  }).then(() => {
+    return network === "live" ? deployer : deployer.deploy(LProposalForTesting);
   }).then(() => {
     return deployer.then(() => s.setAddress(web3.sha3("LLockInstance"), LLock.address));
   }).then(() => {
@@ -58,6 +59,7 @@ function deployLibraries(deployer, network) {
   }).then(() => {
     return deployer.then(() => s.setAddress(web3.sha3("LAppsInstance"), LApps.address));
   }).then(() => {
+    LLock.address = PLock.address;
     LEvents.address = PEvents.address;
     LApps.address = PApps.address;
     return deployer.link(LEvents, [LProposal, EventsManager, ProposalManager]);
@@ -80,8 +82,10 @@ function deployLibraries(deployer, network) {
 }
 
 function deployLAventusTime(_deployer, _network, _storage) {
-  return _deployer.deploy([LAventusTime, LAventusTimeMock, PAventusTime]).then(() => {
-    const timeAddress = _network === "development" ? LAventusTimeMock.address : LAventusTime.address;
+  return _deployer.deploy([LAventusTime, PAventusTime]).then(() => {
+    return _network === "live" ? _deployer : _deployer.deploy(LAventusTimeMock);
+  }).then(() => {
+    const timeAddress = _network === "live" ? LAventusTime.address : LAventusTimeMock.address;
     LAventusTime.address = PAventusTime.address;
     return _deployer.then(() => _storage.setAddress(web3.sha3("LAventusTimeInstance"), timeAddress));
   });


### PR DESCRIPTION
* Fix migration error which was breaking LLock proxying.
* Do not deploy LAventusTimeMock or LProposalForTesting on the main net