### PR TITLE
Release v0.8.0

### DIFF
--- a/AventusProtocol-ReleaseNotes-v0.8.x.md
+++ b/AventusProtocol-ReleaseNotes-v0.8.x.md
@@ -1,0 +1,22 @@
+# Aventus Protocol 0.8.x Release Notes
+
+This set of releases (see v0.7.x for the previous) is for further refactors of contracts and
+interfaces.
+
+The release notes for this version follow, listed by sub-release and category.
+
+## Release 0.8.0 - 2018-08-21
+
+Breaking change:
+* Move protocol AVT ownership to storage contract - approvals must now be made to storage
+
+New methods
+* Voters can now cancel their vote
+
+Internal only minor changes:
+* Remove generic "delegate" term
+* Minor changes for readability
+* Proposal status now uses enum internally
+
+Bug fix:
+* Limit event challenges to events that are active

--- a/contracts/AventusStorage.sol
+++ b/contracts/AventusStorage.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.24;
 
 import "./proxies/PDelegate.sol";
 import "./interfaces/IAventusStorage.sol";
+import './interfaces/IERC20.sol';
 import "./MultiAccess.sol";
 
 // Persistent storage on the blockchain
@@ -9,9 +10,15 @@ import "./MultiAccess.sol";
 // TODO: Use leading and trailing underscores on parameters and return values.
 
 contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
+  bytes32 constant avtContractAddressKey = keccak256(abi.encodePacked("AVTERC20Instance"));
 
-  modifier hasUpdateAccess() {
-    isAllowedAccess();
+  modifier onlyWithWriteAccess() {
+    isAllowedAccess("write");
+    _;
+  }
+
+  modifier onlyWithTransferAVTAccess() {
+    isAllowedAccess("transferAVT");
     _;
   }
 
@@ -54,6 +61,16 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   // some storage key e.g. keccak("vote", voteId, "end") => stored int8 value
   mapping(bytes32 => int8) Int8;
 
+  function transferAVTTo(address _to, uint _tokens) external onlyWithTransferAVTAccess returns (bool retVal_) {
+    IERC20 avt = IERC20(doGetAddress(avtContractAddressKey));
+    retVal_ = avt.transfer(_to, _tokens);
+  }
+
+  function transferAVTFrom(address _from, uint _tokens) external onlyWithTransferAVTAccess returns (bool retVal_) {
+    IERC20 avt = IERC20(doGetAddress(avtContractAddressKey));
+    retVal_ = avt.transferFrom(_from, this, _tokens);
+  }
+
   /**
    * @dev In case we need to extend functionality - avoids copying state
    */
@@ -84,7 +101,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setUInt(bytes32 record, uint value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     UInt[record] = value;
   }
@@ -108,7 +125,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setUInt128(bytes32 record, uint128 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     UInt128[record] = value;
   }
@@ -132,7 +149,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setUInt64(bytes32 record, uint64 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     UInt64[record] = value;
   }
@@ -156,7 +173,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setUInt32(bytes32 record, uint32 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     UInt32[record] = value;
   }
@@ -180,7 +197,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setUInt16(bytes32 record, uint16 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     UInt16[record] = value;
   }
@@ -204,7 +221,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setUInt8(bytes32 record, uint8 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     UInt8[record] = value;
   }
@@ -228,7 +245,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setString(bytes32 record, string value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     String[record] = value;
   }
@@ -252,7 +269,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setAddress(bytes32 record, address value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Address[record] = value;
   }
@@ -276,7 +293,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setBytes(bytes32 record, bytes value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Bytes[record] = value;
   }
@@ -300,7 +317,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setBytes32(bytes32 record, bytes32 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Bytes32[record] = value;
   }
@@ -324,7 +341,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setBytes16(bytes32 record, bytes16 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Bytes16[record] = value;
   }
@@ -348,7 +365,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setBytes8(bytes32 record, bytes8 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Bytes8[record] = value;
   }
@@ -372,7 +389,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setBoolean(bytes32 record, bool value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Boolean[record] = value;
   }
@@ -396,7 +413,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setInt(bytes32 record, int value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Int[record] = value;
   }
@@ -420,7 +437,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setInt128(bytes32 record, int128 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Int128[record] = value;
   }
@@ -444,7 +461,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setInt64(bytes32 record, int64 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Int64[record] = value;
   }
@@ -468,7 +485,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setInt32(bytes32 record, int32 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Int32[record] = value;
   }
@@ -492,7 +509,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setInt16(bytes32 record, int16 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Int16[record] = value;
   }
@@ -516,7 +533,7 @@ contract AventusStorage is MultiAccess, PDelegate, IAventusStorage {
   */
   function setInt8(bytes32 record, int8 value)
     external
-    hasUpdateAccess
+    onlyWithWriteAccess
   {
     Int8[record] = value;
   }

--- a/contracts/EventsManager.sol
+++ b/contracts/EventsManager.sol
@@ -75,20 +75,20 @@ contract EventsManager is IEventsManager, Owned, Versioned {
     LEvents.signedResellTicket(s, _signedMessage, _eventId, _ticketId, _ownerPermission, _newBuyer);
   }
 
-  function registerRole(uint _eventId, string _role, address _delegate) external {
-    LEvents.registerRole(s, _eventId, _role, _delegate);
+  function registerRole(uint _eventId, string _role, address _address) external {
+    LEvents.registerRole(s, _eventId, _role, _address);
   }
 
-  function deregisterRole(uint _eventId, string _role, address _delegate) external {
-    LEvents.deregisterRole(s, _eventId, _role, _delegate);
+  function deregisterRole(uint _eventId, string _role, address _address) external {
+    LEvents.deregisterRole(s, _eventId, _role, _address);
   }
 
-  function addressIsDelegate(uint _eventId, string _role, address _delegate)
+  function roleIsRegistered(uint _eventId, string _role, address _address)
     external
     view
     returns (bool registered_)
   {
-    registered_ = LEvents.addressIsDelegate(s, _eventId, _role, _delegate);
+    registered_ = LEvents.roleIsRegistered(s, _eventId, _role, _address);
   }
 
   function getEventDeposit(uint _capacity, uint _averageTicketPriceInUSCents, uint _ticketSaleStartTime)

--- a/contracts/MultiAccess.sol
+++ b/contracts/MultiAccess.sol
@@ -3,23 +3,27 @@ pragma solidity ^0.4.24;
 import "./Owned.sol";
 
 contract MultiAccess is Owned {
-  event AllowAccessEvent(address indexed accessAddress);
-  event DenyAccessEvent(address indexed accessAddress);
+  event LogAllowAccess(string accessType, address indexed accessAddress);
+  event LogDenyAccess(string accessType, address indexed accessAddress);
 
-  mapping(address => bool) accessAllowed;
+  mapping(bytes32 => bool) accessAllowed;
 
-  function allowAccess(address _address) external onlyOwner {
-    accessAllowed[_address] = true;
-    emit AllowAccessEvent(_address);
+  function allowAccess(string _accessType, address _address) external onlyOwner {
+    accessAllowed[getKey(_accessType, _address)] = true;
+    emit LogAllowAccess(_accessType, _address);
   }
 
-  function denyAccess(address _address) external onlyOwner {
-    accessAllowed[_address] = false;
-    emit DenyAccessEvent(_address);
+  function denyAccess(string _accessType, address _address) external onlyOwner {
+    accessAllowed[getKey(_accessType, _address)] = false;
+    emit LogDenyAccess(_accessType, _address);
   }
 
-  function isAllowedAccess() internal view {
-    require(msg.sender == owner || accessAllowed[msg.sender]);
+  function isAllowedAccess(string _accessType) internal view {
+    require(msg.sender == owner || accessAllowed[getKey(_accessType, msg.sender)]);
+  }
+
+  function getKey(string _accessType, address _address) private pure returns (bytes32 key_) {
+    key_ = keccak256(abi.encodePacked(_accessType, _address));
   }
 
 }

--- a/contracts/ProposalsManager.sol
+++ b/contracts/ProposalsManager.sol
@@ -39,6 +39,10 @@ contract ProposalsManager is IProposalsManager, Owned, Versioned {
     LProposal.castVote(s, _proposalId, _secret, _prevTime);
   }
 
+  function cancelVote(uint _proposalId) external {
+    LProposal.cancelVote(s, _proposalId);
+  }
+
   function revealVote(bytes _signedMessage, uint _proposalId, uint8 _optId) external {
     LProposal.revealVote(s, _signedMessage, _proposalId, _optId);
   }

--- a/contracts/interfaces/IAventusStorage.sol
+++ b/contracts/interfaces/IAventusStorage.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.4.24;
 // TODO: Use leading and trailing underscores on parameters and return values.
 
 interface IAventusStorage {
+  function transferAVTTo(address _to, uint _tokens) external returns (bool retVal_);
+  function transferAVTFrom(address _from, uint _tokens) external returns (bool retVal_);
+
   function getUInt(bytes32 record) external constant returns (uint);
   function setUInt(bytes32 record, uint value) external;
 

--- a/contracts/interfaces/IEventsManager.sol
+++ b/contracts/interfaces/IEventsManager.sol
@@ -60,23 +60,23 @@ interface IEventsManager {
   /**
    * Event emitted for a registerRole transaction.
    */
-  event LogRegisterRole(uint indexed eventId, string role, address indexed delegate);
+  event LogRegisterRole(uint indexed eventId, string role, address indexed _address);
 
   /**
    * Event emitted for a deregisterRole transaction.
    */
-  event LogDeregisterRole(uint indexed eventId, string role, address indexed delegate);
+  event LogDeregisterRole(uint indexed eventId, string role, address indexed _address);
 
   /**
-  * @dev Create an event
-  * @param _eventDesc description or title of the event
-  * @param _eventTime - the actual event time
-  * @param _capacity - number of tickets (capacity) for the event
-  * @param _averageTicketPriceInUSCents  - average ticket price in US Cents
-  * @param _ticketSaleStartTime - expected ticket sale start time
-  * @param _eventSupportURL - verifiable official supporting url for the event
-  * @return eventId_ - id of newly created event
-  */
+   * @dev Create an event
+   * @param _eventDesc description or title of the event
+   * @param _eventTime - the actual event time
+   * @param _capacity - number of tickets (capacity) for the event
+   * @param _averageTicketPriceInUSCents  - average ticket price in US Cents
+   * @param _ticketSaleStartTime - expected ticket sale start time
+   * @param _eventSupportURL - verifiable official supporting url for the event
+   * @return eventId_ - id of newly created event
+   */
   function createEvent(
       string _eventDesc, uint _eventTime, uint _capacity,
       uint _averageTicketPriceInUSCents, uint _ticketSaleStartTime, string _eventSupportURL)
@@ -84,17 +84,17 @@ interface IEventsManager {
     returns (uint eventId_);
 
   /**
-  * @dev Create an event on behalf of a signer
-  * @param _signedMessage a signed message
-  * @param _eventDesc description or title of the event
-  * @param _eventTime - the actual event time
-  * @param _capacity - number of tickets (capacity) for the event
-  * @param _averageTicketPriceInUSCents  - average ticket price in US Cents
-  * @param _ticketSaleStartTime - expected ticket sale start time
-  * @param _eventSupportURL - verifiable official supporting url for the event
-  * @param _owner - address of the event owner
-  * @return uint eventId_ of newly created event
-  */
+   * @dev Create an event on behalf of a signer
+   * @param _signedMessage a signed message
+   * @param _eventDesc description or title of the event
+   * @param _eventTime - the actual event time
+   * @param _capacity - number of tickets (capacity) for the event
+   * @param _averageTicketPriceInUSCents  - average ticket price in US Cents
+   * @param _ticketSaleStartTime - expected ticket sale start time
+   * @param _eventSupportURL - verifiable official supporting url for the event
+   * @param _owner - address of the event owner
+   * @return uint eventId_ of newly created event
+   */
   function signedCreateEvent(
       bytes _signedMessage,
       string _eventDesc, uint _eventTime,  uint _capacity,
@@ -104,71 +104,71 @@ interface IEventsManager {
     returns (uint eventId_);
 
   /**
-  * @dev Cancel an event
-  * @param _eventId - event id for the event to end
-  */
+   * @dev Cancel an event
+   * @param _eventId - event id for the event to end
+   */
   function cancelEvent(uint _eventId) external;
 
   /**
-  * @dev Cancel an event on behalf of a signer
-  * @param _signedMessage a signed message
-  * @param _eventId - event id for the event to end
-  */
+   * @dev Cancel an event on behalf of a signer
+   * @param _signedMessage a signed message
+   * @param _eventId - event id for the event to end
+   */
   function signedCancelEvent(bytes _signedMessage, uint _eventId) external;
 
   /**
-  * @dev Complete the process of event ending to balance the deposits
-  * @param _eventId - event id for the event to end
-  */
+   * @dev Complete the process of event ending to balance the deposits
+   * @param _eventId - event id for the event to end
+   */
   function unlockEventDeposit(uint _eventId) external;
 
   /**
-  * @dev Sell ticket
-  * @param _eventId - event id for the event to end
-  * @param _ticketDetails - ticket details
-  * @param _buyer - address of the ticket buyer
-  */
+   * @dev Sell ticket
+   * @param _eventId - event id for the event to end
+   * @param _ticketDetails - ticket details
+   * @param _buyer - address of the ticket buyer
+   */
   function sellTicket(uint _eventId, string _ticketDetails, address _buyer) external;
 
   /**
-  * @dev Sell ticket on behalf of a signer
-  * @param _signedMessage a signed message
-  * @param _eventId - event id for the event to end
-  * @param _ticketDetails - ticket details
-  * @param _buyer - address of the ticket buyer
-  */
+   * @dev Sell ticket on behalf of a signer
+   * @param _signedMessage a signed message
+   * @param _eventId - event id for the event to end
+   * @param _ticketDetails - ticket details
+   * @param _buyer - address of the ticket buyer
+   */
   function signedSellTicket(bytes _signedMessage, uint _eventId, string _ticketDetails, address _buyer) external;
 
   /**
-  * @dev Refund sale of a ticket
-  * @param _eventId - event id for the event in context
-  * @param _ticketId - ticket Id for the ticket to be refunded
-  */
+   * @dev Refund sale of a ticket
+   * @param _eventId - event id for the event in context
+   * @param _ticketId - ticket Id for the ticket to be refunded
+   */
   function refundTicket(uint _eventId, uint _ticketId) external;
 
   /**
-  * @dev Refund sale of a ticket on behalf of a signer
-  * @param _signedMessage a signed message
-  * @param _eventId - event id for the event in context
-  * @param _ticketId - ticket Id for the ticket to be refunded
-  */
+   * @dev Refund sale of a ticket on behalf of a signer
+   * @param _signedMessage a signed message
+   * @param _eventId - event id for the event in context
+   * @param _ticketId - ticket Id for the ticket to be refunded
+   */
   function signedRefundTicket(bytes _signedMessage, uint _eventId, uint _ticketId) external;
 
   /**
-  * @dev Register a delegate for an event
-  * @param _eventId - ID of the event
-  * @param _role - role must be an aventity type of either "PrimaryDelegate", "SecondaryDelegate" or "Broker"
-  * @param _delegate - delegate address
-  */
-  function registerRole(uint _eventId, string _role, address _delegate) external;
+   * @dev Register an Aventity member for an event
+   * @param _eventId - ID of the event
+   * @param _role - role must be an aventity type of either "PrimaryDelegate", "SecondaryDelegate" or "Broker"
+   * @param _address - member address
+   */
+  function registerRole(uint _eventId, string _role, address _address) external;
 
   /**
-  * @dev Deregister a delegate to an event
-  * @param _eventId - ID of the event
-  * @param _role - role must be an aventity type of either "PrimaryDelegate", "SecondaryDelegate" or "Broker"
-  * @param _delegate - delegate of the event
-  */
-  function deregisterRole(uint _eventId, string _role, address _delegate) external;
+   * @dev Deregister an Aventity member from an event
+   * @param _eventId - ID of the event
+   * @param _role - role must be an aventity type of either "PrimaryDelegate", "SecondaryDelegate" or "Broker"
+   * @param _address - member address
+   */
+  function deregisterRole(uint _eventId, string _role, address _address) external;
 
   /**
    * Sell a ticket on the secondary market.
@@ -192,25 +192,25 @@ interface IEventsManager {
     external;
 
   /**
-  * @dev Check if a delegate is registered for an event
-  * @param _eventId - ID of the event
-  * @param _role - role must be an aventity type of either "PrimaryDelegate", "SecondaryDelegate" or "Broker"
-  * @param _delegate - Delegate to check
-  * @return _registered - returns true if the supplied delegate is registered
-  */
-  function addressIsDelegate(uint _eventId, string _role, address _delegate)
+   * @dev Check if an Aventity member is registered for an event
+   * @param _eventId - ID of the event
+   * @param _role - role must be an aventity type of either "PrimaryDelegate", "SecondaryDelegate" or "Broker"
+   * @param _address - address to check
+   * @return _registered - returns true if the supplied address is registered
+   */
+  function roleIsRegistered(uint _eventId, string _role, address _address)
     external
     view
     returns (bool registered_);
 
   /**
-  * @dev Calculate the appropriate event deposit In USCents and in AVT
-  * @param _capacity - number of tickets (capacity) for the event
-  * @param _averageTicketPriceInUSCents  - average ticket price in US Cents
-  * @param _ticketSaleStartTime - expected ticket sale start time
-  * @return uint depositInUSCents_ calculated deposit in US cents
-  * @return uint depositInAVTDecimals_ calculated deposit in AVT Decimals
-  */
+   * @dev Calculate the appropriate event deposit In USCents and in AVT
+   * @param _capacity - number of tickets (capacity) for the event
+   * @param _averageTicketPriceInUSCents  - average ticket price in US Cents
+   * @param _ticketSaleStartTime - expected ticket sale start time
+   * @return uint depositInUSCents_ calculated deposit in US cents
+   * @return uint depositInAVTDecimals_ calculated deposit in AVT Decimals
+   */
   function getEventDeposit(uint _capacity, uint _averageTicketPriceInUSCents, uint _ticketSaleStartTime)
     external
     view

--- a/contracts/interfaces/IProposalsManager.sol
+++ b/contracts/interfaces/IProposalsManager.sol
@@ -12,6 +12,11 @@ interface IProposalsManager {
   event LogCastVote(address indexed sender, uint indexed proposalId, bytes32 secret, uint prevTime);
 
   /**
+   * Event emitted for a cancelVote transaction.
+   */
+  event LogCancelVote(address indexed sender, uint indexed proposalId);
+
+  /**
    * Event emitted for a revealVote transaction.
    */
   event LogRevealVote(address indexed sender, uint indexed proposalId, uint8 indexed optId, uint revealingStart, uint revealingEnd);
@@ -77,6 +82,13 @@ interface IProposalsManager {
   * @param _prevTime The previous time that locked the user's funds - from getPrevTimeParamForCastVote()
   */
   function castVote(uint _proposalId, bytes32 _secret, uint _prevTime) external;
+
+  /**
+   * Cancel a vote on one of a given proposal's options
+   * NOTE: Vote must be cancelled within the voting period.
+   * @param _proposalId Proposal ID
+   */
+  function cancelVote(uint _proposalId) external;
 
   /**
   * Reveal a vote on a proposal

--- a/contracts/libraries/LAVTManager.sol
+++ b/contracts/libraries/LAVTManager.sol
@@ -1,14 +1,12 @@
 pragma solidity ^0.4.24;
 
 import '../interfaces/IAventusStorage.sol';
-import '../interfaces/IERC20.sol';
 import "./LAventusTime.sol";
 
 // Library for adding functionality for handling AVT funds.
 library LAVTManager  {
   bytes32 constant stakeFundHash = keccak256(abi.encodePacked("stake"));
   bytes32 constant depositFundHash = keccak256(abi.encodePacked("deposit"));
-  bytes32 constant avtContractAddressKey = keccak256(abi.encodePacked("AVTERC20Instance"));
   bytes32 constant oneAVTInUSCentsKey = keccak256(abi.encodePacked("OneAVTInUSCents"));
   bytes32 constant totalAVTFundsKey = keccak256(abi.encodePacked("TotalAVTFunds"));
 
@@ -48,9 +46,8 @@ library LAVTManager  {
 
     decreaseFund(_storage, msg.sender, _fund, _amount);
 
-    IERC20 avt = IERC20(_storage.getAddress(avtContractAddressKey));
-    require (
-      avt.transfer(msg.sender, _amount),
+    require(
+      _storage.transferAVTTo(msg.sender, _amount),
       "Transfer of funds in withdraw must succeed before continuing"
     );
 
@@ -86,9 +83,8 @@ library LAVTManager  {
 
     increaseFund(_storage, msg.sender, _fund, _amount);
 
-    IERC20 avt = IERC20(_storage.getAddress(avtContractAddressKey));
     require (
-      avt.transferFrom(msg.sender, this, _amount),
+      _storage.transferAVTFrom(msg.sender, _amount),
       "Transfer of funds in 'deposit' must succeed before continuing"
     );
 

--- a/contracts/libraries/LAventities.sol
+++ b/contracts/libraries/LAventities.sol
@@ -4,7 +4,6 @@ import '../interfaces/IAventusStorage.sol';
 import './LAVTManager.sol';
 
 library LAventities {
-  bytes32 constant fixedDepositAmountKey = keccak256(abi.encodePacked("Applications", "fixedDepositAmount"));
   bytes32 constant brokerHash = keccak256(abi.encodePacked("Broker"));
   bytes32 constant primaryDelegateHash = keccak256(abi.encodePacked("PrimaryDelegate"));
   bytes32 constant secondaryDelegateHash = keccak256(abi.encodePacked("SecondaryDelegate"));

--- a/migrations/2_libraries.js
+++ b/migrations/2_libraries.js
@@ -171,10 +171,10 @@ function doDeploySubLibraries(_deployer, library) {
   if (library === LProposal) {
     return _deployer.deploy(LProposalWinnings)
     .then(() => _deployer.link(LProposalWinnings, [LProposal, LProposalsEnact]))
-    .then(() => _deployer.deploy(LProposalVoting))
-    .then(() => _deployer.link(LProposalVoting, LProposal))
     .then(() => _deployer.deploy(LProposalsEnact))
-    .then(() => _deployer.link(LProposalsEnact, LProposal));
+    .then(() => _deployer.link(LProposalsEnact, [LProposal, LProposalVoting]))
+    .then(() => _deployer.deploy(LProposalVoting))
+    .then(() => _deployer.link(LProposalVoting, LProposal));
   } else if (library === LEvents) {
     return _deployer.deploy(LEventsCommon)
     .then(() => _deployer.link(LEventsCommon, [LEvents, LEventsEnact]))

--- a/migrations/3_contracts.js
+++ b/migrations/3_contracts.js
@@ -77,7 +77,7 @@ function doDeployProposalsManager(_deployer, _storage) {
 
   return _deployer.deploy(ProposalsManager, _storage.address)
   .then(() => saveInterfaceToStorage(_storage, "IProposalsManager", ProposalsManagerInterface, ProposalsManager))
-  .then(() => _storage.allowAccess(ProposalsManager.address))
+  .then(() => _storage.allowAccess("write", ProposalsManager.address))
 }
 
 function doDeployAVTManager(_deployer, _storage) {
@@ -85,7 +85,8 @@ function doDeployAVTManager(_deployer, _storage) {
 
   return _deployer.deploy(AVTManager, _storage.address)
   .then(() => saveInterfaceToStorage(_storage, "IAVTManager", AVTManagerInterface, AVTManager))
-  .then(() => _storage.allowAccess(AVTManager.address))
+  .then(() => _storage.allowAccess("write", AVTManager.address))
+  .then(() => _storage.allowAccess("transferAVT", AVTManager.address))
 }
 
 function doDeployAventitiesManager(_deployer, _storage) {
@@ -93,7 +94,7 @@ function doDeployAventitiesManager(_deployer, _storage) {
 
   return _deployer.deploy(AventitiesManager, _storage.address)
   .then(() => saveInterfaceToStorage(_storage, "IAventitiesManager", AventitiesManagerInterface, AventitiesManager))
-  .then(() => _storage.allowAccess(AventitiesManager.address));
+  .then(() => _storage.allowAccess("write", AventitiesManager.address));
 }
 
 function doDeployEventsManager(_deployer, _storage) {
@@ -101,14 +102,14 @@ function doDeployEventsManager(_deployer, _storage) {
 
   return _deployer.deploy(EventsManager, _storage.address)
   .then(() => saveInterfaceToStorage(_storage, "IEventsManager", EventsManagerInterface, EventsManager))
-  .then(() => _storage.allowAccess(EventsManager.address));
+  .then(() => _storage.allowAccess("write", EventsManager.address));
 }
 
 function doDeployParameterRegistry(_deployer, _storage) {
   if (!deployParameterRegistry) return _deployer;
 
   return _deployer.deploy(ParameterRegistry, _storage.address)
-  .then(() => _storage.allowAccess(ParameterRegistry.address))
+  .then(() => _storage.allowAccess("write", ParameterRegistry.address))
   .then(() => ParameterRegistry.deployed())
   .then(parameterRegistry => parameterRegistry.setupDefaultParameters());
 }

--- a/test/AventitiesManagerTest.js
+++ b/test/AventitiesManagerTest.js
@@ -23,7 +23,7 @@ contract('AventitiesManager', async () => {
         // Any other account will not have any AVT: give them what they need.
         await avt.transfer(account, amount);
     }
-    await avt.approve(avtManager.address, amount, {from: account});
+    await avt.approve(testHelper.getStorage().address, amount, {from: account});
     await avtManager.deposit("deposit", amount, {from: account});
     return account;
   }
@@ -99,7 +99,7 @@ contract('AventitiesManager', async () => {
 
       for (const fund of funds) {
         // add the fundAmount to account 0
-        await avt.approve(avtManager.address, fundAmount);
+        await avt.approve(testHelper.getStorage().address, fundAmount);
         await avtManager.deposit(fund, fundAmount);
 
         // check balances

--- a/test/EventsManagerEventsTest.js
+++ b/test/EventsManagerEventsTest.js
@@ -207,30 +207,30 @@ contract('EventsManager - event management', async () => {
             await eventsManager.registerRole(eventId, testHelper.primaryDelegateAventityType, primaryDelegate, {from: eventOwner});
           }
 
-          async function registerPrimaryDelegateFails(_delegate) {
-            await testHelper.expectRevert(() => eventsManager.registerRole(eventId, testHelper.primaryDelegateAventityType, primaryDelegate, {from: _delegate}));
+          async function registerPrimaryDelegateFails(_address) {
+            await testHelper.expectRevert(() => eventsManager.registerRole(eventId, testHelper.primaryDelegateAventityType, primaryDelegate, {from: _address}));
           }
 
           async function deregisterPrimaryDelegateSucceeds() {
             await eventsManager.deregisterRole(eventId, testHelper.primaryDelegateAventityType, primaryDelegate, {from: eventOwner});
           }
 
-          async function registerUnknownDelegateRoleFails(_delegate) {
-            await testHelper.expectRevert(() => eventsManager.registerRole(eventId, "unknownAventityType", _delegate, {from: eventOwner}));
+          async function registerUnknownRoleFails(_address) {
+            await testHelper.expectRevert(() => eventsManager.registerRole(eventId, "unknownAventityType", _address, {from: eventOwner}));
           }
 
           it("can register/deregister a primary delegate for an event", async () => {
             await eventsTestHelper.depositAndRegisterAventityMember(primaryDelegate, testHelper.primaryDelegateAventityType, testHelper.evidenceURL, "Registering primary delegate");
 
-            let registered = await eventsManager.addressIsDelegate(eventId, testHelper.primaryDelegateAventityType, primaryDelegate);
+            let registered = await eventsManager.roleIsRegistered(eventId, testHelper.primaryDelegateAventityType, primaryDelegate);
             assert.ok(!registered);
 
             await registerPrimaryDelegateSucceeds();
-            registered = await eventsManager.addressIsDelegate(eventId, testHelper.primaryDelegateAventityType, primaryDelegate);
+            registered = await eventsManager.roleIsRegistered(eventId, testHelper.primaryDelegateAventityType, primaryDelegate);
             assert.ok(registered);
 
             await deregisterPrimaryDelegateSucceeds()
-            registered = await eventsManager.addressIsDelegate(eventId, testHelper.primaryDelegateAventityType, primaryDelegate);
+            registered = await eventsManager.roleIsRegistered(eventId, testHelper.primaryDelegateAventityType, primaryDelegate);
             assert.ok(!registered);
 
             await eventsTestHelper.deregisterAventityAndWithdrawDeposit(primaryDelegate, testHelper.primaryDelegateAventityType);
@@ -239,15 +239,15 @@ contract('EventsManager - event management', async () => {
           it("can register/deregister a secondary delegate for an event", async () => {
             await eventsTestHelper.depositAndRegisterAventityMember(secondaryDelegate, testHelper.secondaryDelegateAventityType, testHelper.evidenceURL, "Registering secondary delegate");
 
-            let registered = await eventsManager.addressIsDelegate(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate);
+            let registered = await eventsManager.roleIsRegistered(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate);
             assert.ok(!registered);
 
             await eventsManager.registerRole(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate, {from: eventOwner});
-            registered = await eventsManager.addressIsDelegate(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate);
+            registered = await eventsManager.roleIsRegistered(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate);
             assert.ok(registered);
 
             await eventsManager.deregisterRole(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate, {from: eventOwner});
-            registered = await eventsManager.addressIsDelegate(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate);
+            registered = await eventsManager.roleIsRegistered(eventId, testHelper.secondaryDelegateAventityType, secondaryDelegate);
             assert.ok(!registered);
 
             await eventsTestHelper.deregisterAventityAndWithdrawDeposit(secondaryDelegate, testHelper.secondaryDelegateAventityType);
@@ -274,7 +274,7 @@ contract('EventsManager - event management', async () => {
 
           it("cannot register a delegate with an unknown role", async () => {
             await eventsTestHelper.depositAndRegisterAventityMember(primaryDelegate, testHelper.primaryDelegateAventityType, testHelper.evidenceURL, "Registering primary delegate");
-            await registerUnknownDelegateRoleFails(primaryDelegate);
+            await registerUnknownRoleFails(primaryDelegate);
             await eventsTestHelper.deregisterAventityAndWithdrawDeposit(primaryDelegate, testHelper.primaryDelegateAventityType);
           });
         });

--- a/test/ProposalsManagerAventityChallengesTest.js
+++ b/test/ProposalsManagerAventityChallengesTest.js
@@ -14,11 +14,17 @@ contract('ProposalsManager - Aventity challenges', async () => {
   const voter1 =  testHelper.getAccount(2);
   const voter2 =  testHelper.getAccount(3);
   const challengeEnder = testHelper.getAccount(4);
-  const ONE_AVT = new web3.BigNumber(1 * 10**18);
-  const stake = ONE_AVT;
-  // const fixedPercentageToWinner = 10;
-  // const fixedPercentageToChallengeEnder = 10;
-  const broker = testHelper.getAccount(4);
+
+  const memberAddress = testHelper.getAccount(5);
+  const fraudulentMemberAddress = testHelper.getAccount(6);
+
+  const memberTypes = [
+      testHelper.brokerAventityType,
+      testHelper.primaryDelegateAventityType,
+      testHelper.secondaryDelegateAventityType
+  ];
+
+  const stake = testHelper.oneAVT;
 
   before(async () => {
     await votingTestHelper.before();
@@ -78,12 +84,19 @@ contract('ProposalsManager - Aventity challenges', async () => {
     assert.equal(votesAgainst, eventArgs.votesAgainst.toNumber());
   }
 
+  async function withdrawDepositsAfterChallengeEnds() {
+    // No one voted. The aventity owner wins their fixed amount...
+    await withdrawDeposit(fixedAmountToWinner(), memberAddress);
+    // ...the challenge ender gets the rest.
+    await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()), challengeEnder);
+  }
+
   async function makeDeposit(_depositAmount, _depositer) {
     if (_depositer != testHelper.getAccount(0)) {
       // Any other account will not have any AVT: give them what they need.
       await avt.transfer(_depositer, _depositAmount);
     }
-    await avt.approve(avtManager.address, _depositAmount, {from: _depositer});
+    await avt.approve(testHelper.getStorage().address, _depositAmount, {from: _depositer});
     await avtManager.deposit('deposit', _depositAmount, {from: _depositer});
   }
 
@@ -96,25 +109,13 @@ contract('ProposalsManager - Aventity challenges', async () => {
       // Any other account will not have any AVT: give them what they need.
       await avt.transfer(_depositer, _stakeAmount);
     }
-    await avt.approve(avtManager.address, _stakeAmount, {from: _depositer});
+    await avt.approve(testHelper.getStorage().address, _stakeAmount, {from: _depositer});
     await avtManager.deposit('stake', _stakeAmount, {from: _depositer});
   }
 
   async function withdrawStake(_withdrawlAmount, _withdrawer) {
     await avtManager.withdraw('stake', _withdrawlAmount, {from: _withdrawer});
   }
-
-  context("Challenge deposit", async () => {
-    it("can get the correct aventity deposit", async () => {
-      let deposit = await getExistingAventityDeposit(validAventityId);
-      assert.equal(deposit.toString(), validAventityDeposit.toString());
-    });
-
-    it("cannot get the aventity deposit for non-existent aventities", async () => {
-      let deposit = await getExistingAventityDeposit(999999);
-      assert.equal(deposit.toNumber(), 0);
-    });
-  });
 
   function fixedAmountToWinner() {
     // Winner currently gets 10%.
@@ -126,96 +127,128 @@ contract('ProposalsManager - Aventity challenges', async () => {
     return validChallengeDeposit.dividedToIntegerBy(10);
   }
 
-  context("Create and end challenge - no votes", async () => {
-    beforeEach(async () => {
-      await registerAventityMember(broker, testHelper.brokerAventityType);
+  for (let j = 0; j < memberTypes.length; ++j) {
+    const memberType = memberTypes[j];
+
+    context(`Create and end ${memberType} challenge - no votes`, async () => {
+      beforeEach(async () => {
+        await registerAventityMember(memberAddress, memberType);
+      });
+
+      afterEach(async () => {
+        await deregisterAventityAndWithdrawDeposit(memberAddress, memberType);
+      });
+
+      after(async () => await testHelper.checkFundsEmpty());
+
+      it("can create and end a challenge to a valid aventity", async () => {
+        await createAventityChallengeSucceeds();
+        await endChallengeAventity(0, 0);
+        await withdrawDepositsAfterChallengeEnds();
+      });
+
+      it("cannot create a challenge to an aventity without sufficient deposit", async () => {
+        const insufficientDeposit = (await getExistingAventityDeposit(validAventityId)).minus(new web3.BigNumber(1));
+        await createAventityChallengeFails(insufficientDeposit, validAventityId);
+      });
+
+      it("cannot create a challenge to deregistered aventity", async () => {
+        await deregisterAventityAndWithdrawDeposit(memberAddress, memberType);
+        validChallengeDeposit = await aventitiesManager.getAventityMemberDeposit(memberType);
+        await makeDeposit(validChallengeDeposit, challengeOwner);
+        await testHelper.expectRevert(() => proposalsManager.createAventityChallenge(validAventityId, {from: challengeOwner}));
+        await withdrawDeposit(validChallengeDeposit, challengeOwner);
+        // registering again so the AfterEach block doesn't break for this test
+        await registerAventityMember(memberAddress, memberType);
+      });
+
+      it("can get the correct aventity deposit", async () => {
+        let deposit = await getExistingAventityDeposit(validAventityId);
+        assert.notEqual(deposit.toNumber(), 0);
+        assert.equal(deposit.toString(), validAventityDeposit.toString());
+      });
     });
 
-    afterEach(async () => {
-      await deregisterAventityAndWithdrawDeposit(broker, testHelper.brokerAventityType);
-    });
+    context(`Create and end ${memberType} challenge - with votes`, async () => {
+      beforeEach(async () => {
+        await registerAventityMember(memberAddress, memberType);
+        await createAventityChallengeSucceeds();
+        await depositStake(stake, voter1);
+        await depositStake(stake, voter2);
+      });
 
-    after(async () => await testHelper.checkFundsEmpty());
+      afterEach(async () => {
+        await withdrawStake(stake, voter1);
+        await withdrawStake(stake, voter2);
+      });
 
-    async function withdrawDepositsAfterChallengeEnds() {
-      // No one voted. The aventity owner wins their fixed amount...
-      await withdrawDeposit(fixedAmountToWinner(), broker);
-      // ...the challenge ender gets the rest.
-      await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()), challengeEnder);
-    }
-
-    it("can create and end a challenge to a valid aventity", async () => {
-      await createAventityChallengeSucceeds();
-      await endChallengeAventity(0, 0);
-      await withdrawDepositsAfterChallengeEnds();
-    });
-
-    it("cannot create a challenge to a non-existing aventity", async () => {
-      const correctDeposit = await getExistingAventityDeposit(validAventityId);
-      const wrongAventityId = 99999;
-      await createAventityChallengeFails(correctDeposit, wrongAventityId);
-    });
-
-    it("cannot create a challenge to an aventity without sufficient deposit", async () => {
-      const insufficientDeposit = (await getExistingAventityDeposit(validAventityId)).minus(new web3.BigNumber(1));
-      await createAventityChallengeFails(insufficientDeposit, validAventityId);
-    });
-
-    it("cannot create more than one challenge to an aventity", async () => {
-      await createAventityChallengeSucceeds();
-      await createAventityChallengeFails(validChallengeDeposit, validAventityId);
-      await endChallengeAventity(0, 0);
-      await withdrawDepositsAfterChallengeEnds();
-    });
-
-    it("cannot end a non-existent challenge", async () => {
-      await createAventityChallengeSucceeds();
-      await testHelper.expectRevert(() => proposalsManager.endProposal(99999999, {from: challengeEnder}));
-      await endChallengeAventity(0, 0);
-      await withdrawDepositsAfterChallengeEnds();
-    });
-
-    it ("cannot deregister an aventity when under challenge", async () => {
-      await createAventityChallengeSucceeds();
-      await testHelper.expectRevert(() => aventitiesManager.deregisterAventity(validAventityId));
-      await endChallengeAventity(0, 0);
-      await withdrawDepositsAfterChallengeEnds();
-    });
-
-    it("cannot create a challenge to deregistered aventity", async () => {
-      await deregisterAventityAndWithdrawDeposit(broker, testHelper.brokerAventityType);
-      validChallengeDeposit = await aventitiesManager.getAventityMemberDeposit(testHelper.brokerAventityType);
-      await makeDeposit(validChallengeDeposit, challengeOwner);
-      await testHelper.expectRevert(() => proposalsManager.createAventityChallenge(validAventityId, {from: challengeOwner}));
-      await withdrawDeposit(validChallengeDeposit, challengeOwner);
-      // registering again so the AfterEach block doesn't break for this test
-      await registerAventityMember(broker, testHelper.brokerAventityType);
-    });
-  });
-
-  context("End challenge - with votes", async () => {
-    let winningsRemainder = 0, newBrokerAccountNum = 5, newBrokerAccount; /*inline declaration to help git align correctly*/
-
-    beforeEach(async () => {
-      newBrokerAccount = testHelper.getAccount(newBrokerAccountNum++);
-      await registerAventityMember(newBrokerAccount, testHelper.brokerAventityType);
-      await createAventityChallengeSucceeds();
-      await depositStake(stake, voter1);
-      await depositStake(stake, voter2);
-    });
-
-    afterEach(async () => {
-      await withdrawStake(stake, voter1);
-      await withdrawStake(stake, voter2);
-    });
-
-    after(async () => {
-      if (winningsRemainder > 0) {
-        console.log("TODO: Deal with remainder of ", winningsRemainder);
-      } else {
+      after(async () => {
         await testHelper.checkFundsEmpty();
-      }
+      });
+
+      it("pays the correct winnings in the case of disagreement winning", async () => {
+        await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
+        const signedMessage = await votingTestHelper.castVote(validChallengeProposalId, 2, voter1);
+        await testHelper.advanceTimeToRevealingStart(validChallengeProposalId);
+        await votingTestHelper.revealVote(signedMessage, validChallengeProposalId, 2, voter1);
+
+        await endChallengeAventity(0, stake);
+        // Challenge lost, the winner is the aventity owner.
+        await withdrawDeposit(fixedAmountToWinner(), memberAddress);
+        // The challenge ender gets their bit.
+
+        await withdrawDeposit(fixedAmountToChallengeEnder(), challengeEnder);
+        // Winning voter gets the rest.
+        await proposalsManager.claimVoterWinnings(validChallengeProposalId, {from: voter1});
+        await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()).minus(fixedAmountToChallengeEnder()), voter1);
+        await deregisterAventityAndWithdrawDeposit(memberAddress, memberType);
+      });
+
+      it("pays the correct winnings in the case of disagreement winning via a 'score draw'", async () => {
+        await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
+        const signedMessage1 = await votingTestHelper.castVote(validChallengeProposalId, 1, voter1);
+        const signedMessage2 = await votingTestHelper.castVote(validChallengeProposalId, 2, voter2);
+        await testHelper.advanceTimeToRevealingStart(validChallengeProposalId);
+        await votingTestHelper.revealVote(signedMessage1, validChallengeProposalId, 1, voter1);
+        await votingTestHelper.revealVote(signedMessage2, validChallengeProposalId, 2, voter2);
+
+        await endChallengeAventity(stake, stake);
+        // Challenge lost, the winner is the aventity.
+        await withdrawDeposit(fixedAmountToWinner(), memberAddress);
+        // The challenge ender gets their bit.
+        await withdrawDeposit(fixedAmountToChallengeEnder(), challengeEnder);
+        // Winning voter gets the rest.
+        await proposalsManager.claimVoterWinnings(validChallengeProposalId, {from: voter2});
+        await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()).minus(fixedAmountToChallengeEnder()), voter2);
+
+        await deregisterAventityAndWithdrawDeposit(memberAddress, memberType);
+      });
+
+      it("pays the correct winnings in the case of disagreement winning via a 'no-score draw'", async () => {
+        await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
+        const signedMessage1 = await votingTestHelper.castVote(validChallengeProposalId, 1, voter1);
+        const signedMessage2 = await votingTestHelper.castVote(validChallengeProposalId, 2, voter2);
+        // No-one reveals their votes before the deadline.
+
+        await endChallengeAventity(0, 0);
+
+        await votingTestHelper.revealVote(signedMessage1, validChallengeProposalId, 1, voter1);
+        await votingTestHelper.revealVote(signedMessage2, validChallengeProposalId, 2, voter2);
+
+        // Challenge lost, the winner is the aventity.
+        await withdrawDeposit(fixedAmountToWinner(), memberAddress);
+        // The challenge ender gets the rest.
+        await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()), challengeEnder);
+
+        await deregisterAventityAndWithdrawDeposit(memberAddress, memberType);
+      });
+
+      // TODO: Implement test: "can only sell and refund tickets if aventity has not been deemed fraudulent" (issue #552)
     });
+  }
+
+  context(`Create and end challenge - fraudulent`, async () => {
+    let winningsRemainder = 0;
 
     async function voteToMarkAventityAsFraudulentAndWithdrawWinnings() {
       await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
@@ -240,73 +273,90 @@ contract('ProposalsManager - Aventity challenges', async () => {
       winningsRemainder += totalVoterWinnings.mod(2).toNumber();
     }
 
-    it("pays the correct winnings in the case of agreement winning", async () => {
+    before(async () => {
+      await registerAventityMember(fraudulentMemberAddress, testHelper.brokerAventityType);
+      await createAventityChallengeSucceeds();
+      await depositStake(stake, voter1);
+      await depositStake(stake, voter2);
       await voteToMarkAventityAsFraudulentAndWithdrawWinnings();
     });
 
-    it("pays the correct winnings in the case of disagreement winning", async () => {
-      await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
-      const signedMessage = await votingTestHelper.castVote(validChallengeProposalId, 2, voter1);
-      await testHelper.advanceTimeToRevealingStart(validChallengeProposalId);
-      await votingTestHelper.revealVote(signedMessage, validChallengeProposalId, 2, voter1);
+    after(async () => {
+      await withdrawStake(stake, voter1);
+      await withdrawStake(stake, voter2);
 
-      await endChallengeAventity(0, stake);
-      // Challenge lost, the winner is the aventity owner.
-      await withdrawDeposit(fixedAmountToWinner(), newBrokerAccount);
-      // The challenge ender gets their bit.
-
-      await withdrawDeposit(fixedAmountToChallengeEnder(), challengeEnder);
-      // Winning voter gets the rest.
-      await proposalsManager.claimVoterWinnings(validChallengeProposalId, {from: voter1});
-      await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()).minus(fixedAmountToChallengeEnder()), voter1);
-      await deregisterAventityAndWithdrawDeposit(newBrokerAccount, testHelper.brokerAventityType);
+      if (winningsRemainder > 0) {
+        console.log("TODO: Deal with remainder of ", winningsRemainder);
+      } else {
+        await testHelper.checkFundsEmpty();
+      }
     });
-
-    it("pays the correct winnings in the case of disagreement winning via a 'score draw'", async () => {
-      await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
-      const signedMessage1 = await votingTestHelper.castVote(validChallengeProposalId, 1, voter1);
-      const signedMessage2 = await votingTestHelper.castVote(validChallengeProposalId, 2, voter2);
-      await testHelper.advanceTimeToRevealingStart(validChallengeProposalId);
-      await votingTestHelper.revealVote(signedMessage1, validChallengeProposalId, 1, voter1);
-      await votingTestHelper.revealVote(signedMessage2, validChallengeProposalId, 2, voter2);
-
-      await endChallengeAventity(stake, stake);
-      // Challenge lost, the winner is the aventity.
-      await withdrawDeposit(fixedAmountToWinner(), newBrokerAccount);
-      // The challenge ender gets their bit.
-      await withdrawDeposit(fixedAmountToChallengeEnder(), challengeEnder);
-      // Winning voter gets the rest.
-      await proposalsManager.claimVoterWinnings(validChallengeProposalId, {from: voter2});
-      await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()).minus(fixedAmountToChallengeEnder()), voter2);
-
-      await deregisterAventityAndWithdrawDeposit(newBrokerAccount, testHelper.brokerAventityType);
-    });
-
-    it("pays the correct winnings in the case of disagreement winning via a 'no-score draw'", async () => {
-      await testHelper.advanceTimeToVotingStart(validChallengeProposalId);
-      const signedMessage1 = await votingTestHelper.castVote(validChallengeProposalId, 1, voter1);
-      const signedMessage2 = await votingTestHelper.castVote(validChallengeProposalId, 2, voter2);
-      // No-one reveals their votes before the deadline.
-
-      await endChallengeAventity(0, 0);
-
-      await votingTestHelper.revealVote(signedMessage1, validChallengeProposalId, 1, voter1);
-      await votingTestHelper.revealVote(signedMessage2, validChallengeProposalId, 2, voter2);
-
-      // Challenge lost, the winner is the aventity.
-      await withdrawDeposit(fixedAmountToWinner(), newBrokerAccount);
-      // The challenge ender gets the rest.
-      await withdrawDeposit(validChallengeDeposit.minus(fixedAmountToWinner()), challengeEnder);
-
-      await deregisterAventityAndWithdrawDeposit(newBrokerAccount, testHelper.brokerAventityType);
-    });
-
-    // TODO: Implement test: "can only sell and refund tickets if aventity has not been deemed fraudulent" (issue #552)
 
     it("cannot deregister aventity if fraudulent", async () => {
-      await voteToMarkAventityAsFraudulentAndWithdrawWinnings();
       // Aventity is now marked as fraudulent - we can not deregister it.
       await testHelper.expectRevert(() => aventitiesManager.deregisterAventity(validAventityId));
     });
+
+    it("cannot re-register aventity if fraudulent", async () => {
+      validAventityDeposit = await aventitiesManager.getAventityMemberDeposit(testHelper.brokerAventityType);
+      await makeDeposit(validAventityDeposit, fraudulentMemberAddress);
+
+      // Aventity is now marked as fraudulent - we can not re-register it.
+      await testHelper.expectRevert(() => aventitiesManager.registerAventityMember(fraudulentMemberAddress, testHelper.brokerAventityType, testHelper.evidenceURL, "Registering aventity"));
+      await withdrawDeposit(validAventityDeposit, fraudulentMemberAddress);
+    });
+
+    it("cannot challenge aventity if fraudulent", async () => {
+      await makeDeposit(validChallengeDeposit, challengeOwner);
+      // Aventity is now marked as fraudulent - we can not challenge it.
+      await testHelper.expectRevert(() => proposalsManager.createAventityChallenge(validAventityId, {from: challengeOwner}));
+      await withdrawDeposit(validChallengeDeposit, challengeOwner);
+    });
+
   });
+
+  context("Create and end challenge - general", async () => {
+    beforeEach(async () => {
+      await registerAventityMember(memberAddress, testHelper.brokerAventityType);
+    });
+
+    afterEach(async () => {
+      await deregisterAventityAndWithdrawDeposit(memberAddress, testHelper.brokerAventityType);
+    });
+
+    after(async () => await testHelper.checkFundsEmpty());
+
+    it("cannot get the aventity deposit for non-existent aventities", async () => {
+      let deposit = await getExistingAventityDeposit(999999);
+      assert.equal(deposit.toNumber(), 0);
+    });
+
+    it("cannot create a challenge to a non-existing aventity", async () => {
+      const correctDeposit = await getExistingAventityDeposit(validAventityId);
+      const wrongAventityId = 99999;
+      await createAventityChallengeFails(correctDeposit, wrongAventityId);
+    });
+
+    it("cannot create more than one challenge to an aventity", async () => {
+      await createAventityChallengeSucceeds();
+      await createAventityChallengeFails(validChallengeDeposit, validAventityId);
+      await endChallengeAventity(0, 0);
+      await withdrawDepositsAfterChallengeEnds();
+    });
+
+    it("cannot end a non-existent challenge", async () => {
+      await createAventityChallengeSucceeds();
+      await testHelper.expectRevert(() => proposalsManager.endProposal(99999999, {from: challengeEnder}));
+      await endChallengeAventity(0, 0);
+      await withdrawDepositsAfterChallengeEnds();
+    });
+
+    it ("cannot deregister an aventity when under challenge", async () => {
+      await createAventityChallengeSucceeds();
+      await testHelper.expectRevert(() => aventitiesManager.deregisterAventity(validAventityId));
+      await endChallengeAventity(0, 0);
+      await withdrawDepositsAfterChallengeEnds();
+    });
+  });
+
 });

--- a/test/ProposalsManagerProposalsTest.js
+++ b/test/ProposalsManagerProposalsTest.js
@@ -31,7 +31,7 @@ contract('ProposalsManager - Proposal set-up', async () => {
         // Any other account will not have any AVT: give them what they need.
         await avt.transfer(owner, deposit);
     }
-    await avt.approve(avtManager.address, deposit, {from: owner});
+    await avt.approve(testHelper.getStorage().address, deposit, {from: owner});
     await avtManager.deposit("deposit", deposit, {from: owner});
 
     await proposalsManager.createGovernanceProposal(desc, {from: owner});

--- a/test/ProxyTest.js
+++ b/test/ProxyTest.js
@@ -33,7 +33,7 @@ contract('Proxy testing', async () => {
 
   async function createProposal(desc) {
     proposalDeposit = await proposalsManager.getGovernanceProposalDeposit();
-    await avt.approve(avtManager.address, proposalDeposit);
+    await avt.approve(aventusStorage.address, proposalDeposit);
     await avtManager.deposit("deposit", proposalDeposit);
 
     await proposalsManager.createGovernanceProposal(desc);

--- a/test/helpers/eventsTestHelper.js
+++ b/test/helpers/eventsTestHelper.js
@@ -1,12 +1,13 @@
 const EventsManager = artifacts.require("EventsManager");
 const ProposalsManager = artifacts.require("ProposalsManager");
 const AventitiesManager = artifacts.require("AventitiesManager");
+const AventusStorage = artifacts.require("AventusStorage");
 const testHelper = require("./testHelper");
 const web3Utils = require('web3-utils');
 
 const oneDay = new web3.BigNumber(86400);  // seconds in one day. Solidity uses uint256.
 const oneWeek = oneDay.times(7);
-let eventsManager, proposalsManager, avt, avtManager;
+let eventsManager, proposalsManager, avt, avtManager, storage;
 
 let validEventId, eventDeposit;
 
@@ -33,6 +34,7 @@ async function before(_brokerAddress, _eventOwner) {
 
   eventsManager = await EventsManager.deployed();
   aventitiesManager = await AventitiesManager.deployed();
+  storage = await AventusStorage.deployed();
   proposalsManager = testHelper.getProposalsManager();
   avtManager =  testHelper.getAVTManager();
 
@@ -46,7 +48,7 @@ async function makeDeposit(_amount, _depositer) {
     // Any other account will not have any AVT: give them what they need.
     await avt.transfer(_depositer, _amount);
   }
-  await avt.approve(avtManager.address, _amount, {from: _depositer});
+  await avt.approve(storage.address, _amount, {from: _depositer});
   await avtManager.deposit("deposit", _amount, {from: _depositer});
 }
 

--- a/test/helpers/testHelper.js
+++ b/test/helpers/testHelper.js
@@ -17,6 +17,7 @@ const secondaryDelegateAventityType = 'SecondaryDelegate';
 const invalidAventityType = 'invalid';
 
 const evidenceURL = "http://www.example.com/events?eventid=1111";
+const ONE_AVT = new web3.BigNumber(1 * 10**18);
 
 let blockChainTime = new web3.BigNumber(0);
 let aventusStorage, avtAddress, proposalsManager, realTimeInstance, mockTimeInstance;
@@ -116,7 +117,7 @@ function getEventArgs(eventListenerFunction) {
         lastEventBlockNumber = event.blockNumber;
         resolve(event.args);
       } else if (log.length > 1) {
-        reject("Duplicate events: ", log.length);
+        reject(`Duplicate events: ${log.length}`);
       }
     });
   });
@@ -183,5 +184,6 @@ module.exports = {
     secondaryDelegateAventityType,
     invalidAventityType,
     evidenceURL,
-    oneDay
+    oneDay,
+    oneAVT: ONE_AVT
 }

--- a/test/helpers/votingTestHelper.js
+++ b/test/helpers/votingTestHelper.js
@@ -35,6 +35,11 @@ async function castVote(_proposalId, _optionId, _address) {
   return signedMessage;
 }
 
+async function cancelVote(_proposalId, _address) {
+  let address = _address || testHelper.getAccount(0);
+  await proposalsManager.cancelVote(_proposalId, {from: address});
+}
+
 async function revealVote(_signedMessage, _proposalId, _optionId, _address) {
   let address = _address || testHelper.getAccount(0);
   await proposalsManager.revealVote(_signedMessage, _proposalId, _optionId, {from: address});
@@ -50,6 +55,7 @@ async function getAventusTime() {
 module.exports = {
   before,
   castVote,
+  cancelVote,
   getSignatureSecret,
   getSignedMessage,
   revealVote,


### PR DESCRIPTION
## Release 0.8.0 - 2018-08-21

Breaking change:
* Move protocol AVT ownership to storage contract - approvals must now be made to storage

New methods
* Voters can now cancel their vote

Internal only minor changes:
* Remove generic "delegate" term
* Minor changes for readability
* Proposal status now uses enum internally

Bug fix:
* Limit event challenges to events that are active